### PR TITLE
Remove layer workaround and bump lambda memory

### DIFF
--- a/src/world-id/resources.ts
+++ b/src/world-id/resources.ts
@@ -5,7 +5,6 @@ import {
   Architecture,
   FunctionUrlAuthType,
   LayerVersion,
-  Runtime,
   type Function as Lambda,
 } from "aws-cdk-lib/aws-lambda";
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
@@ -13,15 +12,9 @@ import {
   NodejsFunction,
   type NodejsFunctionProps,
 } from "aws-cdk-lib/aws-lambda-nodejs";
-import { RetentionDays } from "aws-cdk-lib/aws-logs";
 import { CfnApplication } from "aws-cdk-lib/aws-sam";
 import type { ISecret } from "aws-cdk-lib/aws-secretsmanager";
 import { Queue } from "aws-cdk-lib/aws-sqs";
-import {
-  AwsCustomResource,
-  AwsCustomResourcePolicy,
-  PhysicalResourceId,
-} from "aws-cdk-lib/custom-resources";
 import { Construct } from "constructs";
 
 import { ON_VERIFIED_EVENT, WORLD_ID_EVENTS_SOURCE } from "./events";
@@ -61,47 +54,17 @@ export class WorldIdVerifier extends Construct {
       location: {
         applicationId:
           "arn:aws:serverlessrepo:us-east-1:990551184979:applications/lambda-layer-canvas-nodejs",
-        semanticVersion: "2.9.1",
+        semanticVersion: "2.9.3",
       },
     });
     nodeCanvasLayer.applyRemovalPolicy(RemovalPolicy.DESTROY);
-
-    /**
-     * Temporary workaround until following will be merged:
-     * https://github.com/charoitel/lambda-layer-canvas-nodejs/pull/7
-     */
-    const lv = new AwsCustomResource(this, "Get Layer Version", {
-      resourceType: "Custom::GetStackResources",
-      onUpdate: {
-        outputPaths: ["StackResources.0"],
-        service: "CloudFormation",
-        action: "describeStackResources",
-        parameters: {
-          StackName: nodeCanvasLayer.ref,
-        },
-        physicalResourceId: PhysicalResourceId.fromResponse(
-          "StackResources.0.PhysicalResourceId",
-        ),
-      },
-      policy: AwsCustomResourcePolicy.fromSdkCalls({
-        resources: AwsCustomResourcePolicy.ANY_RESOURCE,
-      }),
-      installLatestAwsSdk: false,
-      logRetention: RetentionDays.ONE_WEEK,
-    });
-    lv.node.addDependency(nodeCanvasLayer);
-
-    const nodeCanvasLayerVersion = LayerVersion.fromLayerVersionArn(
-      this,
-      "NodeCanvasLayerVersion",
-      lv.getResponseField("StackResources.0.PhysicalResourceId"),
-    );
 
     const qrGenerator = new NodejsFunction(this, "qr-generator", {
       description: "Generates PNG image for QR code",
       ...(props.defaultLambdaProps ?? {}),
       architecture: Architecture.X86_64,
       timeout: Duration.seconds(10),
+      memorySize: 1024,
       reservedConcurrentExecutions: 100,
       bundling: {
         ...(props.defaultLambdaProps?.bundling ?? {}),
@@ -116,10 +79,14 @@ export class WorldIdVerifier extends Construct {
         define: {
           self: "globalThis",
         },
-        target: "node14.18",
       },
-      runtime: Runtime.NODEJS_14_X, // Canvas layer only supports 14.x for now
-      layers: [nodeCanvasLayerVersion],
+      layers: [
+        LayerVersion.fromLayerVersionArn(
+          this,
+          "NodeCanvasLayerVersion",
+          nodeCanvasLayer.getAtt("Outputs.LayerVersion").toString(),
+        ),
+      ],
     });
 
     const qrGeneratorUrl = qrGenerator.addFunctionUrl({


### PR DESCRIPTION
This PR removes `node-canvas` layer workaround (as my PR there was merged and new version published).

In additional we bumping the lambda memory (as processor as it's coupled on lambda) to make it little bit speedier.