### PR TITLE
feat: prevent bot default flow if user already verified

### DIFF
--- a/src/world-id/check-is-user-verified.ts
+++ b/src/world-id/check-is-user-verified.ts
@@ -1,0 +1,40 @@
+import type { REST } from "@discordjs/rest";
+
+import type {
+  APIApplicationCommandInteraction,
+  RESTGetAPIGuildRolesResult,
+} from "discord-api-types/v10";
+
+import { Routes } from "discord-api-types/v10";
+
+export const checkIsUserAlreadyVerified = async ({
+  message,
+  rest,
+  ROLES_TO_ASSIGN,
+}: {
+  message: APIApplicationCommandInteraction;
+  rest: REST;
+  ROLES_TO_ASSIGN: Array<string>;
+}) => {
+  if (!message.guild_id) {
+    return false;
+  }
+
+  const existingRoles = (await rest.get(
+    Routes.guildRoles(message.guild_id),
+  )) as RESTGetAPIGuildRolesResult;
+
+  const verifiedUserRolesNames = message.member?.roles
+    .flatMap((roleId) => existingRoles.find((r) => r.id === roleId)?.name ?? [])
+    .sort();
+
+  const isUserAlreadyValidated =
+    verifiedUserRolesNames !== undefined &&
+    verifiedUserRolesNames.length > 0 &&
+    ROLES_TO_ASSIGN.length === verifiedUserRolesNames.length &&
+    ROLES_TO_ASSIGN.sort().every(
+      (element, index) => element === verifiedUserRolesNames[index],
+    );
+
+  return isUserAlreadyValidated;
+};

--- a/src/world-id/followup-messages/already-verified.ts
+++ b/src/world-id/followup-messages/already-verified.ts
@@ -1,0 +1,33 @@
+import { EmbedBuilder } from "@discordjs/builders";
+import type { REST } from "@discordjs/rest";
+import {
+  Routes,
+  type RESTPostAPIWebhookWithTokenJSONBody,
+} from "discord-api-types/v10";
+
+export async function sendAlreadyVerifiedErrorMessage({
+  rest,
+  applicationId,
+  interactionToken,
+}: {
+  rest: REST;
+  applicationId: string;
+  interactionToken: string;
+}) {
+  /** @see {@link https://discordjs.guide/popular-topics/embeds.html#embed-preview} */
+  const embed = new EmbedBuilder()
+    .setColor([222, 84, 78])
+    .setTitle("Hmm... looks like you already verified with this server before")
+    .setDescription(
+      "A single person can only verify once with each server to ensure everyone who is verified is human.",
+    )
+    .setTimestamp();
+
+  const body: RESTPostAPIWebhookWithTokenJSONBody = {
+    embeds: [embed.toJSON()],
+  };
+
+  return rest.patch(Routes.webhookMessage(applicationId, interactionToken), {
+    body,
+  });
+}

--- a/src/world-id/resources.ts
+++ b/src/world-id/resources.ts
@@ -152,6 +152,9 @@ export class WorldIdVerifier extends Construct {
         APP_NAME: this.node.tryGetContext("app_name"),
         ACTION_ID: this.node.tryGetContext("action_id"),
         SIGNAL: this.node.tryGetContext("signal"),
+
+        //@REVIEW Added the 'ROLES_TO_ASSIGN' variable here so that it was possible to get it in 'resources.queue-processing.ts'
+        ROLES_TO_ASSIGN: props.rolesToAssignToVerifiedUsers.join(","),
         SIGNAL_DESCRIPTION: this.node.tryGetContext("signal_description"),
       },
     });


### PR DESCRIPTION
Fixes [WID-95](https://linear.app/worldcoin/issue/WID-95/discord-bot-should-show-error-if-you-have-already-verified-an-account)

- Please, take a look at [this](https://github.com/worldcoin/world-id-discord-bot/compare/igorosipov/wid-95-discord-bot-should-show-error-if-you?expand=1#diff-dd1c64018325754f7a07090d92cd139c6f4a8394f718595ec6cfd3055e34205dR156) line. Not sure if this variable should be here.

### Check result

- You can test it on this server: https://discord.gg/WRVgZvJN7b

--- 
![image](https://user-images.githubusercontent.com/89008845/187937078-f062857a-5f2a-4eff-b2fd-984bbf97c9e5.png)
